### PR TITLE
Defer parsing of JS

### DIFF
--- a/Snippets/defer_js.php
+++ b/Snippets/defer_js.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ *  Defer parsing of JS to remove render-blocking warning in speedtest
+ */
+
+function defer_parsing_of_js($url)
+{
+  if (is_admin()) return $url; //don't break WP Admin
+  if (false === strpos($url, '.js')) return $url;
+  if (strpos($url, 'jquery.js')) return $url;
+  return str_replace(' src', ' defer src', $url);
+}
+add_filter('script_loader_tag', 'defer_parsing_of_js', 10);


### PR DESCRIPTION
Defer parsing of JS to remove render-blocking warning in speedtest